### PR TITLE
#2 Add endpoint for admin/employees to signin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,7 @@
     "parserOptions": {
         "ecmaVersion": 2018
     },
-    "rules": {}
+    "rules": {
+        "indent": ["error", 4]
+    }
 }

--- a/spec/controllers/user.spec.js
+++ b/spec/controllers/user.spec.js
@@ -1,22 +1,24 @@
+require('dotenv').config();
 const request = require('request');
+const jwt = require('jsonwebtoken');
 const baseUrl = "http://localhost:3500/api/v1";
 
 describe('UserController Test Suite', () => {
+    let endPoint;
 
     beforeAll(() => { });
 
     afterAll(() => { });
 
     describe('POST /auth/create-user', () => {
-        let endPoint;
         let testData;
 
         beforeAll(() => {
             endPoint = baseUrl + '/auth/create-user';
         });
-        
+
         beforeEach(() => {
-            const data = {
+            let data = {
                 first_name: 'Mark',
                 last_name: 'Spencer',
                 email: 'mark.spencer-' + Date.now() + '@oc.com',
@@ -84,6 +86,72 @@ describe('UserController Test Suite', () => {
 
                 expect(response.statusCode).toBe(201);
                 expect(realBody.status).toBe('success');
+                done();
+            });
+        });
+    });
+
+    describe('POST /auth/signin', () => {
+        let testCredentials;
+
+        beforeAll(() => {
+            endPoint = baseUrl + '/auth/signin';
+        });
+
+        beforeEach(() => {
+            data = {
+                email: 'mark.spencer-1573098608494@oc.com',
+                password: 'markspencer'
+            };
+
+            testCredentials = Object.assign({}, data);
+        });
+
+        it('should fail authentication if email input is blank', (done) => {
+            testCredentials.email = '';
+
+            request.post(endPoint, { form: testCredentials }, (error, response, body) => {
+                const realBody = JSON.parse(body);
+
+                expect(response.statusCode).toBe(400);
+                expect(realBody.status).toBe('error');
+                done();
+            });
+        });
+
+        it('should fail authentication if an invalid email is supplied', (done) => {
+            testCredentials.email = 'i-do-code@me.com';
+
+            request.post(endPoint, { form: testCredentials }, (error, response, body) => {
+                const realBody = JSON.parse(body);
+
+                expect(response.statusCode).toBe(404);
+                expect(realBody.status).toBe('error');
+                done();
+            });
+        });
+
+        it('should fail authentication if blank(invalid) password is supplied', (done) => {
+            testCredentials.password = '';
+
+            request.post(endPoint, { form: testCredentials }, (error, response, body) => {
+                const realBody = JSON.parse(body);
+
+                expect(response.statusCode).toBe(400);
+                expect(realBody.status).toBe('error');
+                done();
+            });
+        });
+
+        it('should pass authentication if valid credentials are supplied', (done) => {
+            request.post(endPoint, { form: data }, (error, response, body) => {
+                const realBody = JSON.parse(body);
+                const decodedToken = jwt.verify(realBody.data.token, process.env.JWT_SECRET);
+
+                expect(response.statusCode).toBe(200);
+                expect(realBody.status).toBe('success');
+                expect(realBody.data.token).not.toBe(undefined);
+                expect((decodedToken.userId === realBody.data.userId)).toBeTruthy();// verify token with expected value
                 done();
             });
         });

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (req, res, next) => {
+    try {
+        const { token } = req.headers.authorization.split(' ')[1];
+        const decodedToken = jwt.verify(token, process.env.JWT_SECRET);
+
+        if (req.body.userId && req.body.userId !== decodedToken.userId) {
+            throw new Error('Token verification failed');
+        } else {
+            next();
+        }
+    } catch (error) {
+        res.status(400).json({ status: 'error', error });
+    }
+};

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -2,4 +2,5 @@ const userController = require('../controllers/user');
 
 module.exports = (router) => {
     router.post('/auth/create-user', userController.createOne);
+    router.post('/auth/signin', userController.signIn);
 };


### PR DESCRIPTION
#### What does this PR do?
Implement endpoint for users to signin whether admin or employee

#### Description of Task to be completed?
POST /auth/signin

#### How should this be manually tested?
- Clone the project
- Run ``npm install`` to install node dependencies
- Run ``npm run start`` to start the app
- Run the following endpoint from your Postman app
    **http://localhost:{SERVER_PORT}/api/v1/auth/signin**

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#2  #3  

#### Screenshots (if appropriate)
#### Questions: