### PR TITLE
#6 Add endpoint for deleting gif posts

### DIFF
--- a/src/controllers/gif.js
+++ b/src/controllers/gif.js
@@ -147,4 +147,27 @@ module.exports = {
             });
         }
     },
+
+    deletePost: (req, res) => {
+        const status = 'error';
+        const { params: { gifId } } = req;
+
+        if (gifId === undefined || Number.isSafeInteger(gifId)) {
+            res.status(400).json({ status, error: '' });
+        } else {
+            db.query('DELETE FROM posts WHERE post_type_id = 1 AND id = $1 RETURNING title', [gifId], (err, result) => {
+                try {
+                    if (err) {
+                        throw err;
+                    }
+
+                    const reportMessage = result.rowCount < 0 ? 'not' : '';
+                    res.status(200).json({ status: 'success', data: { message: `GIF post ${reportMessage} successfully deleted` } });
+                } catch (e) {
+                    console.log('[Posts-Del] DB-Error: ', e.message || e.error.message);
+                    res.status(500).json({ status, error: 'The GIF post could not be deleted' });
+                }
+            });
+        }
+    },
 };

--- a/src/routes/gif.js
+++ b/src/routes/gif.js
@@ -6,4 +6,5 @@ module.exports = (router) => {
     router.post('/gifs', auth, multerWare, gifController.createPost);
     router.post('/gifs/:gifId/comment', auth, gifController.createPostComment);
     router.get('/gifs/:gifId', auth, gifController.getPost);
+    router.delete('/gifs/:gifId', auth, gifController.deletePost);
 };


### PR DESCRIPTION
#### What does this PR do?
Implement functionality for employees to delete a gif post

#### Description of Task to be completed?
DELETE /gifs/{gif-id}

#### How should this be manually tested?
- Clone the project
- Run ``npm install`` to install node dependencies
- Run ``npm run start`` to start the app
- Run the following endpoint from your Postman app
    **DELETE http://localhost:{SERVER_PORT}/api/v1/gifs/{gif-id}**

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#6 

#### Screenshots (if appropriate)
#### Questions: