### PR TITLE
#32 Add endpoint to view all article/gif posts as a feed

### DIFF
--- a/src/controllers/feed.js
+++ b/src/controllers/feed.js
@@ -1,5 +1,33 @@
 const db = require('../configs/db');
 
 module.exports = {
-    getPosts: async (req, res) => {},
+    getPosts: async (req, res) => {
+        db.query('SELECT id, title, content, image_url, post_type_id, user_id, created_at FROM posts ORDER BY created_at DESC', [], (err, result) => {
+            try {
+                if (err) {
+                    throw err;
+                }
+
+                const feeds = result.rows.map((row) => {
+                    const {
+                        id, title, content: article, image_url: url, post_type_id: postTypeId,
+                        user_id: authorId, created_at: createdOn,
+                    } = row;
+
+                    return {
+                        id,
+                        createdOn,
+                        title,
+                        ...(postTypeId === 1 ? { url } : { article }),
+                        authorId,
+                    };
+                });
+
+                res.status(200).json({ status: 'success', data: feeds });
+            } catch (e) {
+                console.error('[Feed] DB-Error', e.message || e.error.message);
+                res.status(500).json({ status: 'error', error: 'The article/gif posts could not be retrieved' });
+            }
+        });
+    },
 };

--- a/src/routes/feed.js
+++ b/src/routes/feed.js
@@ -1,6 +1,6 @@
 const feedController = require('../controllers/feed');
 const auth = require('../middlewares/auth');
 
-module.exports = router => {
+module.exports = (router) => {
     router.get('/feed', auth, feedController.getPosts);
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,11 +1,13 @@
 const articleRoutes = require('./article');
 const gifRoutes = require('./gif');
 const userRoutes = require('./user');
+const feedRoutes = require('./feed');
 
 module.exports = (router) => {
     articleRoutes(router);
     gifRoutes(router);
     userRoutes(router);
+    feedRoutes(router);
 
     return router;
 };


### PR DESCRIPTION
#### What does this PR do?
Implement functionality for users to view all article/gif posts with most-recent displayed first

#### Description of Task to be completed?
GET /feed

#### How should this be manually tested?
- Clone the project
- Run ``npm install`` to install node dependencies
- Run ``npm run start`` to start the app
- Run the following endpoint from your Postman app
    **GET http://localhost:{SERVER_PORT}/api/v1/feed**

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#32 

#### Screenshots (if appropriate)
#### Questions: